### PR TITLE
Fixed a few hiccups before release

### DIFF
--- a/pretend-codegen/Cargo.toml
+++ b/pretend-codegen/Cargo.toml
@@ -21,5 +21,5 @@ lazy_static = "1.4"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.5"
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 thiserror = "1.0"

--- a/pretend/src/client.rs
+++ b/pretend/src/client.rs
@@ -9,8 +9,8 @@
 //! This method takes a method, url, header and body (as raw bytes) and should return
 //! a response with raw bytes as body.
 //!
-//! Implementations should be marked with [`client::async_trait`] due to Rust limitations
-//! with futures and traits.
+//! Implementations should be marked with [`client::async_trait`](`self::async_trait`) due to Rust
+//! limitations with futures and traits.
 
 pub use async_trait::async_trait;
 pub use bytes::Bytes;


### PR DESCRIPTION
- A missing feature on syn preventing pretend-codegen to compile
- An invalid link on pretend::client documentation