### PR TITLE
Do not require static lifetime for bytes bodies

### DIFF
--- a/pretend-codegen/src/method/body.rs
+++ b/pretend-codegen/src/method/body.rs
@@ -15,7 +15,7 @@ pub(crate) fn implement_body(method: &TraitItemMethod) -> IResult<TokenStream> {
         }
         BodyKind::Body => {
             quote! {
-                let body = pretend::internal::Body::<()>::Raw(body.as_ref());
+                let body = pretend::internal::Body::<()>::Raw(pretend::client::Bytes::from(body));
             }
         }
         BodyKind::Form => {

--- a/pretend/src/internal.rs
+++ b/pretend/src/internal.rs
@@ -19,7 +19,7 @@ where
     /// No body
     None,
     /// Raw bytes
-    Raw(&'static [u8]),
+    Raw(Bytes),
     /// Form
     Form(&'a T),
     /// Json
@@ -73,7 +73,7 @@ where
 
         let (headers, body) = match body {
             Body::None => (headers, None),
-            Body::Raw(raw) => (headers, Some(Bytes::from_static(raw))),
+            Body::Raw(raw) => (headers, Some(raw)),
             Body::Form(form) => {
                 headers.insert(
                     CONTENT_TYPE,

--- a/pretend/src/lib.rs
+++ b/pretend/src/lib.rs
@@ -70,7 +70,7 @@
 //! Query parameters and bodies are provided as method parameters. Body type is guessed based on
 //! the parameter name:
 //!
-//! - Parameter `body` will be sent as raw bytes. This requires the body to have 'static lifetime.
+//! - Parameter `body` will be sent as raw bytes.
 //! - Parameter `form` will be serialized as form-encoded using `serde`.
 //! - Parameter `json` will be serialized as JSON using `serde`.
 //!
@@ -87,7 +87,7 @@
 //! #[pretend]
 //! trait HttpBin {
 //!     #[request(method = "POST", path = "/anything")]
-//!     async fn post_bytes(&self, body: &'static [u8]) -> Result<()>;
+//!     async fn post_bytes(&self, body: Vec<u8>) -> Result<()>;
 //!
 //!     #[request(method = "POST", path = "/anything")]
 //!     async fn post_string(&self, body: &'static str) -> Result<()>;


### PR DESCRIPTION
Instead of using AsRef<[u8]>, we now rely on Bytes::from.
This allow Bytes to consume static and non-static
data, making the body field more convenient.