### PR TITLE
Propagate visibility keyword to the generated trait

### DIFF
--- a/pretend-codegen/src/lib.rs
+++ b/pretend-codegen/src/lib.rs
@@ -33,6 +33,7 @@ pub fn pretend(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 fn implement_pretend(attr: PretendAttr, item: ItemTrait) -> Result<TokenStream2> {
     let name = &item.ident;
+    let vis = &item.vis;
     let items = &item.items;
     let kind = parse_client_kind(name, attr, items)?;
     let methods = items
@@ -46,7 +47,7 @@ fn implement_pretend(attr: PretendAttr, item: ItemTrait) -> Result<TokenStream2>
     let send_sync = send_sync_traits_impl(&kind);
     let tokens = quote! {
         #attr
-        trait #name {
+        #vis trait #name {
             #(#items)*
         }
 

--- a/pretend/tests/test_visibility.rs
+++ b/pretend/tests/test_visibility.rs
@@ -1,0 +1,32 @@
+mod runtimes;
+mod server;
+
+use self::api::TestApi;
+use pretend::resolver::UrlResolver;
+use pretend::{Pretend, Url};
+use pretend_reqwest::Client as RClient;
+
+mod api {
+    use pretend::{pretend, request, Result};
+
+    #[pretend]
+    pub trait TestApi {
+        #[request(method = "GET", path = "/method")]
+        async fn get(&self) -> Result<String>;
+    }
+}
+
+fn new_client() -> impl TestApi {
+    let url = Url::parse(server::URL).unwrap();
+    Pretend::new(RClient::default(), UrlResolver::new(url))
+}
+
+#[test]
+fn pretend_generates_pub_visibility() {
+    server::test(|| {
+        runtimes::block_on(async {
+            let result = new_client().get().await;
+            assert!(result.is_ok());
+        })
+    })
+}


### PR DESCRIPTION
Pretend previously generated traits with the (default)
private visibility even if the trait was declared as public.