### PR TITLE
Style: worked-around rustfmt

### DIFF
--- a/pretend-awc/src/lib.rs
+++ b/pretend-awc/src/lib.rs
@@ -51,10 +51,8 @@ impl LocalClient for Client {
         let status = response.status();
         let headers = response.headers();
         let headers = headers.iter().map(create_header).collect::<HeaderMap>();
-        let result = response
-            .body()
-            .await
-            .map_err(|err| Error::Body(Box::new(err)))?;
+        let future = response.body();
+        let result = future.await.map_err(|err| Error::Body(Box::new(err)))?;
         Ok(Response::new(status, headers, Bytes::from(result.to_vec())))
     }
 }

--- a/pretend-codegen/src/method/checks.rs
+++ b/pretend-codegen/src/method/checks.rs
@@ -24,8 +24,8 @@ fn check_no_where_clause(sig: &Signature) -> Result<()> {
 }
 
 pub(crate) fn check_correct_receiver(method: &TraitItemMethod) -> Result<()> {
-    let receiver = get_receiver(method)
-        .ok_or_else(|| Error::new_spanned(&method.sig, UNSUPPORTED_RECEIVER))?;
+    let receiver = get_receiver(method);
+    let receiver = receiver.ok_or_else(|| Error::new_spanned(&method.sig, UNSUPPORTED_RECEIVER))?;
     get_good_mutability(receiver).ok_or_else(|| Error::new_spanned(receiver, UNSUPPORTED_RECEIVER))
 }
 

--- a/pretend-codegen/src/method/headers.rs
+++ b/pretend-codegen/src/method/headers.rs
@@ -6,8 +6,8 @@ use quote::quote;
 use syn::{Attribute, Error, Result, TraitItemMethod};
 
 pub(crate) fn implement_headers(method: &TraitItemMethod) -> Result<TokenStream> {
-    let headers = method
-        .attrs
+    let attrs = &method.attrs;
+    let headers = attrs
         .iter()
         .filter_map(|attr| parse_name_value_2_attr(attr, "header", "name", "value"))
         .collect::<Vec<_>>();

--- a/pretend-codegen/src/method/request.rs
+++ b/pretend-codegen/src/method/request.rs
@@ -6,7 +6,6 @@ use syn::{Error, Result, TraitItemMethod};
 
 pub(crate) fn get_request(method: &TraitItemMethod) -> Result<(String, String)> {
     let attrs = &method.attrs;
-
     let single = attrs
         .iter()
         .filter_map(|attr| parse_name_value_2_attr(attr, "request", "method", "path"))

--- a/pretend/examples/templating.rs
+++ b/pretend/examples/templating.rs
@@ -27,9 +27,7 @@ fn create_pretend() -> impl HttpBin {
 async fn main() {
     let pretend = create_pretend();
 
-    let result = pretend
-        .get("get", "Header", 1, 2, "something")
-        .await
-        .unwrap();
+    let future = pretend.get("get", "Header", 1, 2, "something");
+    let result = future.await.unwrap();
     println!("{}", result);
 }


### PR DESCRIPTION
rustfmt loves to put chained method calls on new lines.
This commit tries to split the chains to have less lines
spanned by rustfmt.