### PR TITLE
Removed request and header attributes

### DIFF
--- a/pretend-codegen/src/method/attr.rs
+++ b/pretend-codegen/src/method/attr.rs
@@ -1,0 +1,14 @@
+use crate::utils::{parse_name_value_2_attr, WithTokens};
+use syn::Attribute;
+
+pub(crate) fn parse_request_attr(
+    attr: &Attribute,
+) -> Option<WithTokens<Option<(String, String)>, Attribute>> {
+    parse_name_value_2_attr(attr, "request", "method", "path")
+}
+
+pub(crate) fn parse_header_attr(
+    attr: &Attribute,
+) -> Option<WithTokens<Option<(String, String)>, Attribute>> {
+    parse_name_value_2_attr(attr, "header", "name", "value")
+}

--- a/pretend-codegen/src/method/headers.rs
+++ b/pretend-codegen/src/method/headers.rs
@@ -1,6 +1,7 @@
 use crate::errors::{Report, INVALID_HEADER, METHOD_FAILURE};
 use crate::format::format;
-use crate::utils::{parse_name_value_2_attr, WithTokens};
+use crate::method::parse_header_attr;
+use crate::utils::WithTokens;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Error, Result, TraitItemMethod};
@@ -9,7 +10,7 @@ pub(crate) fn implement_headers(method: &TraitItemMethod) -> Result<TokenStream>
     let attrs = &method.attrs;
     let headers = attrs
         .iter()
-        .filter_map(|attr| parse_name_value_2_attr(attr, "header", "name", "value"))
+        .filter_map(parse_header_attr)
         .collect::<Vec<_>>();
 
     let implem = if headers.is_empty() {

--- a/pretend-codegen/src/method/request.rs
+++ b/pretend-codegen/src/method/request.rs
@@ -1,14 +1,15 @@
 use crate::errors::{
     ErrorsExt, INVALID_REQUEST, MISSING_REQUEST, TOO_MANY_REQUESTS, TOO_MANY_REQUESTS_HINT,
 };
-use crate::utils::{parse_name_value_2_attr, Single};
+use crate::method::parse_request_attr;
+use crate::utils::Single;
 use syn::{Error, Result, TraitItemMethod};
 
 pub(crate) fn get_request(method: &TraitItemMethod) -> Result<(String, String)> {
     let attrs = &method.attrs;
     let single = attrs
         .iter()
-        .filter_map(|attr| parse_name_value_2_attr(attr, "request", "method", "path"))
+        .filter_map(parse_request_attr)
         .collect::<Single<_>>();
 
     match single {

--- a/pretend/examples/blocking.rs
+++ b/pretend/examples/blocking.rs
@@ -1,4 +1,4 @@
-use pretend::{pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::BlockingClient;
 
 // This example show how the use of a blocking client

--- a/pretend/examples/bodies.rs
+++ b/pretend/examples/bodies.rs
@@ -1,4 +1,4 @@
-use pretend::{header, pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 use serde::Serialize;
 

--- a/pretend/examples/headers.rs
+++ b/pretend/examples/headers.rs
@@ -1,4 +1,4 @@
-use pretend::{header, pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 
 // This example show how to send various headers to https://httpbin.org

--- a/pretend/examples/methods.rs
+++ b/pretend/examples/methods.rs
@@ -1,4 +1,4 @@
-use pretend::{pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 
 // This example show how to send HTTP requests to https://httpbin.org

--- a/pretend/examples/queries.rs
+++ b/pretend/examples/queries.rs
@@ -1,4 +1,4 @@
-use pretend::{pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 use serde::Serialize;
 

--- a/pretend/examples/responses.rs
+++ b/pretend/examples/responses.rs
@@ -1,4 +1,4 @@
-use pretend::{header, pretend, request, Json, JsonResult, Pretend, Response, Result, Url};
+use pretend::{pretend, Json, JsonResult, Pretend, Response, Result, Url};
 use pretend_reqwest::Client;
 use serde::Deserialize;
 

--- a/pretend/examples/templating.rs
+++ b/pretend/examples/templating.rs
@@ -1,4 +1,4 @@
-use pretend::{header, pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 
 // This example show how to use templating to customize paths and headers

--- a/pretend/src/lib.rs
+++ b/pretend/src/lib.rs
@@ -16,7 +16,7 @@
 //! A REST API is described by annotating a trait:
 //!
 //! ```rust
-//! use pretend::{pretend, request, Result};
+//! use pretend::{pretend, Result};
 //!
 //! #[pretend]
 //! trait HttpBin {
@@ -34,7 +34,7 @@
 //! ```rust
 //! use pretend::{Pretend, Url};
 //! use pretend_reqwest::Client;
-//! # use pretend::{pretend, request, Result};
+//! # use pretend::{pretend, Result};
 //! # #[pretend]
 //! # trait HttpBin {
 //! #     #[request(method = "POST", path = "/anything")]
@@ -56,7 +56,7 @@
 //! Headers are provided as attributes using `header`.
 //!
 //! ```rust
-//! use pretend::{header, pretend, request, Result};
+//! use pretend::{pretend, Result};
 //!
 //! #[pretend]
 //! trait HttpBin {
@@ -77,7 +77,7 @@
 //! Query parameter is passed with the `query` parameter. It is also serialized using `serde`.
 //!
 //! ```rust
-//! use pretend::{pretend, request, Json, Result};
+//! use pretend::{pretend, Json, Result};
 //! use serde::Serialize;
 //!
 //! #[derive(Serialize)]
@@ -115,7 +115,7 @@
 //! types inside a [`Response`]. This also allows accessing response headers.
 //!
 //! ```rust
-//! use pretend::{pretend, request, Json, JsonResult, Response, Result};
+//! use pretend::{pretend, Json, JsonResult, Response, Result};
 //! use serde::Deserialize;
 //!
 //! #[derive(Deserialize)]
@@ -154,7 +154,7 @@
 //! any type that implement `Display` is supported.
 //!
 //! ```rust
-//! use pretend::{header, pretend, request, Json, Pretend, Result};
+//! use pretend::{pretend, Json, Pretend, Result};
 //! use pretend_reqwest::Client;
 //! use serde::Deserialize;
 //! use std::collections::HashMap;
@@ -193,7 +193,7 @@
 //! Blocking implementations will need a blocking client implementation.
 //!
 //! ```rust
-//! use pretend::{pretend, request, Pretend, Result, Url};
+//! use pretend::{pretend, Pretend, Result, Url};
 //! use pretend_reqwest::BlockingClient;
 //!
 //! #[pretend]
@@ -286,7 +286,7 @@ mod errors;
 pub use self::errors::{Error, Result};
 pub use http;
 pub use http::{HeaderMap, StatusCode};
-pub use pretend_codegen::{header, pretend, request};
+pub use pretend_codegen::pretend;
 pub use serde;
 pub use url;
 pub use url::Url;

--- a/pretend/tests/build-sources/attribute.rs
+++ b/pretend/tests/build-sources/attribute.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend(local)]
 trait Test1 {

--- a/pretend/tests/build-sources/bodies.rs
+++ b/pretend/tests/build-sources/bodies.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test {

--- a/pretend/tests/build-sources/generics.rs
+++ b/pretend/tests/build-sources/generics.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test {

--- a/pretend/tests/build-sources/headers.rs
+++ b/pretend/tests/build-sources/headers.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{header, pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test {

--- a/pretend/tests/build-sources/inconsistent_async.rs
+++ b/pretend/tests/build-sources/inconsistent_async.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test1 {}

--- a/pretend/tests/build-sources/receivers.rs
+++ b/pretend/tests/build-sources/receivers.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test {

--- a/pretend/tests/build-sources/requests.rs
+++ b/pretend/tests/build-sources/requests.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use pretend::{pretend, request, Result};
+use pretend::{pretend, Result};
 
 #[pretend]
 trait Test {

--- a/pretend/tests/test_blocking_local.rs
+++ b/pretend/tests/test_blocking_local.rs
@@ -2,7 +2,7 @@ mod runtimes;
 mod server;
 
 use pretend::resolver::UrlResolver;
-use pretend::{pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::BlockingClient;
 use pretend_reqwest::Client;
 

--- a/pretend/tests/test_construction.rs
+++ b/pretend/tests/test_construction.rs
@@ -2,7 +2,7 @@ mod runtimes;
 mod server;
 
 use pretend::resolver::UrlResolver;
-use pretend::{pretend, request, Pretend, Result, Url};
+use pretend::{pretend, Pretend, Result, Url};
 use pretend_reqwest::Client;
 
 #[pretend]

--- a/pretend/tests/test_output.rs
+++ b/pretend/tests/test_output.rs
@@ -2,7 +2,7 @@ mod runtimes;
 mod server;
 
 use pretend::http::{HeaderValue, StatusCode};
-use pretend::{pretend, request, Error, Json, JsonResult, Pretend, Response, Result, Url};
+use pretend::{pretend, Error, Json, JsonResult, Pretend, Response, Result, Url};
 use pretend_reqwest::Client;
 
 type TestDataResult = JsonResult<server::TestData, server::ErrorData>;

--- a/pretend/tests/test_pretend.rs
+++ b/pretend/tests/test_pretend.rs
@@ -1,7 +1,7 @@
 mod runtimes;
 mod server;
 
-use pretend::{header, pretend, request, Json, Pretend, Result, Url};
+use pretend::{pretend, Json, Pretend, Result, Url};
 use pretend_reqwest::Client;
 use std::collections::HashMap;
 

--- a/pretend/tests/test_visibility.rs
+++ b/pretend/tests/test_visibility.rs
@@ -7,7 +7,7 @@ use pretend::{Pretend, Url};
 use pretend_reqwest::Client as RClient;
 
 mod api {
-    use pretend::{pretend, request, Result};
+    use pretend::{pretend, Result};
 
     #[pretend]
     pub trait TestApi {


### PR DESCRIPTION
Similar to serde, the crate should only
expose a single attribute (pretend).
This attribute will process nested attributes
and discard them.