### PR TITLE
Report inconsistent async more accurately

### DIFF
--- a/pretend-codegen/src/errors.rs
+++ b/pretend-codegen/src/errors.rs
@@ -6,8 +6,11 @@ pub(crate) const METHOD_FAILURE: &str = "Failed to generate method implementatio
 pub(crate) const INVALID_ATTR: &str = "Expected `#[pretend]` or `#[pretend(?Send)]`";
 pub(crate) const UNSUPPORTED_ATTR_SYNC: &str =
     "`?Send` is not supported for blocking implementation";
+pub(crate) const NO_METHOD: &str = "Please declare at least one method for this trait";
 pub(crate) const INCONSISTENT_ASYNC: &str =
-    "Unable to deduce if this trait is async or not. Please declare at least one method and mark either all of them as async or none of them as async.";
+    "Unable to deduce if this trait is async or not. Please mark either all methods or none as async.";
+pub(crate) const INCONSISTENT_ASYNC_ASYNC_HINT: &str = "async method defined here";
+pub(crate) const INCONSISTENT_ASYNC_NON_ASYNC_HINT: &str = "non-async method defined here";
 pub(crate) const UNSUPPORTED_TRAIT_ITEM: &str = "Only methods are supported";
 pub(crate) const UNSUPPORTED_GENERICS: &str = "Generics are not supported";
 pub(crate) const UNSUPPORTED_RECEIVER: &str = "Method must take `&self` as receiver";

--- a/pretend/tests/builds/inconsistent_async.stderr
+++ b/pretend/tests/builds/inconsistent_async.stderr
@@ -1,14 +1,26 @@
-error: Unable to deduce if this trait is async or not. Please declare at least one method and mark either all of them as async or none of them as async.
+error: Please declare at least one method for this trait
  --> $DIR/inconsistent_async.rs:6:7
   |
 6 | trait Test1 {}
   |       ^^^^^
 
-error: Unable to deduce if this trait is async or not. Please declare at least one method and mark either all of them as async or none of them as async.
+error: Unable to deduce if this trait is async or not. Please mark either all methods or none as async.
  --> $DIR/inconsistent_async.rs:9:7
   |
 9 | trait Test2 {
   |       ^^^^^
+
+error: async method defined here
+  --> $DIR/inconsistent_async.rs:13:5
+   |
+13 |     async fn test_2(&self) -> Result<()>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: non-async method defined here
+  --> $DIR/inconsistent_async.rs:11:5
+   |
+11 |     fn test_1(&self) -> Result<()>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `?Send` is not supported for blocking implementation
   --> $DIR/inconsistent_async.rs:16:1


### PR DESCRIPTION
The diagnostic will now highlight conflicting
async and non-async functions, or propose to
implement at least one method only when relevant.