### PR TITLE
implement Send and Sync for Error

### DIFF
--- a/pretend/src/errors.rs
+++ b/pretend/src/errors.rs
@@ -10,16 +10,16 @@ use thiserror::Error;
 pub enum Error {
     /// Error when creating a client implementation
     #[error("Failed to create client")]
-    Client(#[source] Box<dyn error::Error>),
+    Client(#[source] Box<dyn error::Error + Send + Sync>),
     /// Error when building the request
     #[error("Invalid request")]
-    Request(#[source] Box<dyn error::Error>),
+    Request(#[source] Box<dyn error::Error + Send + Sync>),
     /// Error when executing the request
     #[error("Failed to execute request")]
-    Response(#[source] Box<dyn error::Error>),
+    Response(#[source] Box<dyn error::Error + Send + Sync>),
     /// Error when parsing the response body
     #[error("Failed to read response body")]
-    Body(#[source] Box<dyn error::Error>),
+    Body(#[source] Box<dyn error::Error + Send + Sync>),
     /// HTTP status error
     ///
     /// This error is returned when the request failed with


### PR DESCRIPTION
It's very common that an error implements Send and Sync.
Some popular error handling crates such as [anyhow](https://crates.io/crates/anyhow) require that [the error is Send and Sync](https://docs.rs/anyhow/1.0.41/anyhow/struct.Error.html).
