### PR TITLE
Distinguish between local and non local errors

### DIFF
--- a/pretend-awc/src/lib.rs
+++ b/pretend-awc/src/lib.rs
@@ -7,9 +7,11 @@ pub use awc;
 
 use awc::http::{HeaderName, HeaderValue};
 use awc::Client as AClient;
-use pretend::client::{async_trait, Bytes, LocalClient, Method};
+use pretend::client::{async_trait, Bytes, Method};
 use pretend::http::header::{HeaderName as PHeaderName, HeaderValue as PHeaderValue};
-use pretend::{Error, HeaderMap, Response, Result, Url};
+use pretend::local::client::Client as PLClient;
+use pretend::local::{Error, Result};
+use pretend::{HeaderMap, Response, Url};
 
 /// `awc` based `pretend` client
 #[derive(Clone, Default)]
@@ -28,7 +30,7 @@ impl Client {
 }
 
 #[async_trait(?Send)]
-impl LocalClient for Client {
+impl PLClient for Client {
     async fn execute(
         &self,
         method: Method,

--- a/pretend-codegen/src/lib.rs
+++ b/pretend-codegen/src/lib.rs
@@ -141,7 +141,7 @@ fn client_implem(kind: &ClientKind) -> TokenStream2 {
             pretend::client::Client
         },
         ClientKind::AsyncLocal => quote! {
-            pretend::client::LocalClient
+            pretend::local::client::Client
         },
         ClientKind::Blocking => quote! {
             pretend::client::BlockingClient

--- a/pretend-codegen/src/method.rs
+++ b/pretend-codegen/src/method.rs
@@ -66,7 +66,7 @@ fn implement_method(method: &TraitItemMethod, kind: &ClientKind) -> Result<Token
             let url = support.create_url(path)?;
             #query
 
-            let response = #execute_request ?;
+            let response = #execute_request?;
             pretend::internal::IntoResponse::into_response(response)
         }
     })

--- a/pretend/src/client.rs
+++ b/pretend/src/client.rs
@@ -39,21 +39,6 @@ pub trait Client {
     ) -> Result<Response<Bytes>>;
 }
 
-/// `pretend` local client
-///
-/// See module level documentation for more information.
-#[async_trait(?Send)]
-pub trait LocalClient {
-    /// Execute a request
-    async fn execute(
-        &self,
-        method: Method,
-        url: Url,
-        headers: HeaderMap,
-        body: Option<Bytes>,
-    ) -> Result<Response<Bytes>>;
-}
-
 /// `pretend` blocking client
 ///
 /// See module level documentation for more information.
@@ -66,23 +51,4 @@ pub trait BlockingClient {
         headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<Response<Bytes>>;
-}
-
-/// `pretend` local client
-///
-/// See module level documentation for more information.
-#[async_trait(?Send)]
-impl<C> LocalClient for C
-where
-    C: Client,
-{
-    async fn execute(
-        &self,
-        method: Method,
-        url: Url,
-        headers: HeaderMap,
-        body: Option<Bytes>,
-    ) -> Result<Response<Bytes>> {
-        Client::execute(self, method, url, headers, body).await
-    }
 }

--- a/pretend/src/lib.rs
+++ b/pretend/src/lib.rs
@@ -264,11 +264,12 @@
 //! - Introduce more attributes to mark method parameters (body, json, params)
 //! - Introduce interceptors
 
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
 pub mod client;
 pub mod internal;
+pub mod local;
 pub mod resolver;
 
 mod errors;

--- a/pretend/src/local.rs
+++ b/pretend/src/local.rs
@@ -1,0 +1,4 @@
+pub mod client;
+mod errors;
+
+pub use errors::*;

--- a/pretend/src/local/client.rs
+++ b/pretend/src/local/client.rs
@@ -1,0 +1,37 @@
+use super::Result;
+use crate::{client, HeaderMap, Response, Url};
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::Method;
+
+/// `pretend` local client
+///
+/// See module level documentation for more information.
+#[async_trait(?Send)]
+pub trait Client {
+    /// Execute a request
+    async fn execute(
+        &self,
+        method: Method,
+        url: Url,
+        headers: HeaderMap,
+        body: Option<Bytes>,
+    ) -> Result<Response<Bytes>>;
+}
+
+#[async_trait(?Send)]
+impl<C> Client for C
+where
+    C: client::Client,
+{
+    async fn execute(
+        &self,
+        method: Method,
+        url: Url,
+        headers: HeaderMap,
+        body: Option<Bytes>,
+    ) -> Result<Response<Bytes>> {
+        let response = C::execute(self, method, url, headers, body).await?;
+        Ok(response)
+    }
+}

--- a/pretend/src/local/errors.rs
+++ b/pretend/src/local/errors.rs
@@ -2,25 +2,27 @@ use crate::StatusCode;
 use std::{error, result};
 use thiserror::Error;
 
-/// Pretend errors
+/// Pretend errors for local clients
 ///
 /// This error type wraps errors emitted
 /// by `pretend` or by client implementations.
-/// It requires wrapped errors to be Send and Sync.
+/// It does not require wrapped errors to be
+/// Send and Sync, and should be used with local
+/// clients.
 #[derive(Error, Debug)]
 pub enum Error {
     /// Error when creating a client implementation
     #[error("Failed to create client")]
-    Client(#[source] Box<dyn error::Error + 'static + Send + Sync>),
+    Client(#[source] Box<dyn error::Error + 'static>),
     /// Error when building the request
     #[error("Invalid request")]
-    Request(#[source] Box<dyn error::Error + 'static + Send + Sync>),
+    Request(#[source] Box<dyn error::Error + 'static>),
     /// Error when executing the request
     #[error("Failed to execute request")]
-    Response(#[source] Box<dyn error::Error + 'static + Send + Sync>),
+    Response(#[source] Box<dyn error::Error + 'static>),
     /// Error when parsing the response body
     #[error("Failed to read response body")]
-    Body(#[source] Box<dyn error::Error + 'static + Send + Sync>),
+    Body(#[source] Box<dyn error::Error + 'static>),
     /// HTTP status error
     ///
     /// This error is returned when the request failed with
@@ -32,3 +34,15 @@ pub enum Error {
 
 /// Pretend Result type
 pub type Result<T> = result::Result<T, Error>;
+
+impl From<crate::Error> for Error {
+    fn from(err: crate::errors::Error) -> Self {
+        match err {
+            crate::Error::Client(err) => Error::Client(err),
+            crate::Error::Request(err) => Error::Request(err),
+            crate::Error::Response(err) => Error::Response(err),
+            crate::Error::Body(err) => Error::Body(err),
+            crate::Error::Status(status) => Error::Status(status),
+        }
+    }
+}

--- a/pretend/tests/test_blocking_local.rs
+++ b/pretend/tests/test_blocking_local.rs
@@ -1,6 +1,7 @@
 mod runtimes;
 mod server;
 
+use pretend::local::Result as LocalResult;
 use pretend::resolver::UrlResolver;
 use pretend::{pretend, request, Pretend, Result, Url};
 use pretend_reqwest::BlockingClient;
@@ -9,7 +10,7 @@ use pretend_reqwest::Client;
 #[pretend(?Send)]
 trait TestApiLocal {
     #[request(method = "GET", path = "/method")]
-    async fn get(&self) -> Result<String>;
+    async fn get(&self) -> LocalResult<String>;
 }
 
 #[pretend]

--- a/pretend/tests/test_clients.rs
+++ b/pretend/tests/test_clients.rs
@@ -5,8 +5,10 @@ mod server;
 use clients_tester::{
     ClientsTester, TestableClient, TokioTestableClient, TokioTestableLocalClient,
 };
-use pretend::client::{Bytes, Client, LocalClient, Method};
-use pretend::{HeaderMap, Response, Result, Url};
+use pretend::client::{Bytes, Client, Method};
+use pretend::local::client::Client as LocalClient;
+use pretend::local::Result;
+use pretend::{HeaderMap, Response, Url};
 use pretend_awc::Client as AClient;
 use pretend_isahc::Client as IClient;
 use pretend_reqwest::{BlockingClient as RBlockingClient, Client as RClient};


### PR DESCRIPTION
The goal of this commit is to introduce Send + Sync
traits to errors wrapped in Error. This conflicts
with local client implementations, that may not
support Send + Sync errors.

To workaround this issue, we introduce a new local
module, in which a local version of Error is put in
place. Local clients will return this error type
instead. Standard and blocking clients will still
return the existing Error type, that will be enriched
with the Send + Sync bounds.