### PR TITLE
Make boxed errors Send + Sync by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
 
       - run: cargo test
 
+  test-default-features-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - run: cd tests/default-features-build && cargo test
+
   analyze:
     runs-on: ubuntu-latest
     steps:
@@ -66,7 +79,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: "0.16.0"
-          args: "--exclude-files pretend/tests/*.rs --exclude-files pretend-codegen/*.rs --exclude-files pretend-codegen/method/*.rs"
+          args: "--exclude-files pretend/tests/*.rs --exclude-files pretend-codegen/*.rs --exclude-files pretend-codegen/method/*.rs --exclude-files tests/default-features-build/src/*.rs --exclude-files tests/default-features-build/tests/*.rs --exclude-files tests/default-features-build/tests/builds/*.rs"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/pretend-awc/Cargo.toml
+++ b/pretend-awc/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["web-programming::http-client"]
 readme = "README.md"
 
 [dependencies]
-pretend = { path = "../pretend",  version = "0.2.0" }
+pretend = { path = "../pretend",  version = "0.2.0", features = ["local-error"] }
 awc = "2.0"

--- a/pretend-awc/src/lib.rs
+++ b/pretend-awc/src/lib.rs
@@ -47,12 +47,12 @@ impl LocalClient for Client {
             request.send()
         };
 
-        let mut response = future.await.map_err(|err| Error::Response(Box::new(err)))?;
+        let mut response = future.await.map_err(Error::response)?;
         let status = response.status();
         let headers = response.headers();
         let headers = headers.iter().map(create_header).collect::<HeaderMap>();
         let future = response.body();
-        let result = future.await.map_err(|err| Error::Body(Box::new(err)))?;
+        let result = future.await.map_err(Error::body)?;
         Ok(Response::new(status, headers, Bytes::from(result.to_vec())))
     }
 }

--- a/pretend-isahc/src/lib.rs
+++ b/pretend-isahc/src/lib.rs
@@ -31,7 +31,7 @@ impl Client {
     /// This constructor creates a client implementation
     /// for `pretend` using a default `isahc` client.
     pub fn new() -> Result<Self> {
-        let client = HttpClient::new().map_err(|err| Error::Client(Box::new(err)))?;
+        let client = HttpClient::new().map_err(Error::client)?;
         Ok(Client { client })
     }
 }
@@ -57,15 +57,15 @@ impl PClient for Client {
             builder.body(AsyncBody::empty())
         };
 
-        let request = request.map_err(|err| Error::Request(Box::new(err)))?;
+        let request = request.map_err(Error::request)?;
         let response = self.client.send_async(request).await;
-        let mut response = response.map_err(|err| Error::Response(Box::new(err)))?;
+        let mut response = response.map_err(Error::response)?;
 
         let status = mem::take(response.status_mut());
         let headers = mem::take(response.headers_mut());
         let mut body = Vec::new();
         let result = response.copy_to(&mut body).await;
-        result.map_err(|err| Error::Body(Box::new(err)))?;
+        result.map_err(Error::body)?;
         Ok(Response::new(status, headers, Bytes::from(body)))
     }
 }

--- a/pretend-reqwest/src/blocking.rs
+++ b/pretend-reqwest/src/blocking.rs
@@ -32,13 +32,13 @@ impl PBlockingClient for BlockingClient {
             builder = builder.body(body);
         }
         let response = builder.send();
-        let mut response = response.map_err(|err| Error::Response(Box::new(err)))?;
+        let mut response = response.map_err(Error::response)?;
 
         let status = response.status();
         let headers = mem::take(response.headers_mut());
 
         let bytes = response.bytes();
-        let bytes = bytes.map_err(|err| Error::Body(Box::new(err)))?;
+        let bytes = bytes.map_err(Error::body)?;
 
         Ok(PResponse::new(status, headers, bytes))
     }

--- a/pretend-reqwest/src/lib.rs
+++ b/pretend-reqwest/src/lib.rs
@@ -48,13 +48,13 @@ impl PClient for Client {
             builder = builder.body(body);
         }
         let response = builder.send().await;
-        let mut response = response.map_err(|err| Error::Response(Box::new(err)))?;
+        let mut response = response.map_err(Error::response)?;
 
         let status = response.status();
         let headers = mem::take(response.headers_mut());
 
         let bytes = response.bytes().await;
-        let bytes = bytes.map_err(|err| Error::Body(Box::new(err)))?;
+        let bytes = bytes.map_err(Error::body)?;
 
         Ok(PResponse::new(status, headers, bytes))
     }

--- a/pretend/Cargo.toml
+++ b/pretend/Cargo.toml
@@ -35,3 +35,6 @@ rustc_version = "0.2"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread"] }
 trybuild = "1.0"
 
+[features]
+default = []
+local-error = []

--- a/pretend/src/errors.rs
+++ b/pretend/src/errors.rs
@@ -2,32 +2,78 @@ use crate::StatusCode;
 use std::{error, result};
 use thiserror::Error;
 
-/// Pretend errors
-///
-/// This error type wraps errors emitted
-/// by `pretend` or by client implementations.
-#[derive(Error, Debug)]
-pub enum Error {
-    /// Error when creating a client implementation
-    #[error("Failed to create client")]
-    Client(#[source] Box<dyn error::Error>),
-    /// Error when building the request
-    #[error("Invalid request")]
-    Request(#[source] Box<dyn error::Error>),
-    /// Error when executing the request
-    #[error("Failed to execute request")]
-    Response(#[source] Box<dyn error::Error>),
-    /// Error when parsing the response body
-    #[error("Failed to read response body")]
-    Body(#[source] Box<dyn error::Error>),
-    /// HTTP status error
-    ///
-    /// This error is returned when the request failed with
-    /// an HTTP error status. It is only returned when methods
-    /// returns bodies.
-    #[error("HTTP {0}")]
-    Status(StatusCode),
+macro_rules! impl_error {
+    ($ty:ty, $($b:tt)*) => {
+        /// Pretend errors
+        ///
+        /// This error type wraps errors emitted
+        /// by `pretend` or by client implementations.
+        #[derive(Error, Debug)]
+        pub enum Error {
+            /// Error when creating a client implementation
+            #[error("Failed to create client")]
+            Client(#[source] $ty),
+            /// Error when building the request
+            #[error("Invalid request")]
+            Request(#[source] $ty),
+            /// Error when executing the request
+            #[error("Failed to execute request")]
+            Response(#[source] $ty),
+            /// Error when parsing the response body
+            #[error("Failed to read response body")]
+            Body(#[source] $ty),
+            /// HTTP status error
+            ///
+            /// This error is returned when the request failed with
+            /// an HTTP error status. It is only returned when methods
+            /// returns bodies.
+            #[error("HTTP {0}")]
+            Status(StatusCode),
+        }
+
+        impl Error {
+            /// Construct a new `Client` error
+            pub fn client<E>(err: E) -> Self
+            where
+                E: $($b)*,
+            {
+                Error::Client(Box::new(err))
+            }
+
+            /// Construct a new `Request` error
+            pub fn request<E>(err: E) -> Self
+            where
+                E: $($b)*,
+            {
+                Error::Request(Box::new(err))
+            }
+
+            /// Construct a new `Response` error
+            pub fn response<E>(err: E) -> Self
+            where
+                E: $($b)*,
+            {
+                Error::Response(Box::new(err))
+            }
+
+            /// Construct a new `Body` error
+            pub fn body<E>(err: E) -> Self
+            where
+                E: $($b)*,
+            {
+                Error::Body(Box::new(err))
+            }
+        }
+    };
 }
+
+#[cfg(not(feature = "local-error"))]
+impl_error!(
+    Box<dyn error::Error + 'static + Send + Sync>,
+    error::Error + 'static + Send + Sync
+);
+#[cfg(feature = "local-error")]
+impl_error!(Box<dyn error::Error + 'static>, error::Error + 'static);
 
 /// Pretend Result type
 pub type Result<T> = result::Result<T, Error>;

--- a/pretend/src/internal.rs
+++ b/pretend/src/internal.rs
@@ -49,7 +49,7 @@ where
     pub fn create_url(&self, path: &str) -> Result<Url> {
         let resolver = &self.pretend.resolver;
         let result = resolver.resolve_url(path);
-        result.map_err(|err| Error::Request(Box::new(err)))
+        result.map_err(Error::request)
     }
 
     /// Execute a request
@@ -128,7 +128,7 @@ where
                 headers.insert(CONTENT_TYPE, content_type);
 
                 let encoded = serde_urlencoded::to_string(form);
-                let encoded = encoded.map_err(|err| Error::Request(Box::new(err)))?;
+                let encoded = encoded.map_err(Error::request)?;
                 let body = Some(Bytes::from(encoded));
 
                 (headers, body)
@@ -138,7 +138,7 @@ where
                 headers.insert(CONTENT_TYPE, content_type);
 
                 let encoded = serde_json::to_vec(json);
-                let encoded = encoded.map_err(|err| Error::Request(Box::new(err)))?;
+                let encoded = encoded.map_err(Error::request)?;
                 let body = Some(Bytes::from(encoded));
 
                 (headers, body)
@@ -157,15 +157,15 @@ where
         let mut pairs = url.query_pairs_mut();
         let serializer = serde_urlencoded::Serializer::new(&mut pairs);
         let result = query.serialize(serializer);
-        result.map_err(|err| Error::Request(Box::new(err)))?;
+        result.map_err(Error::request)?;
     }
     Ok(url)
 }
 
 /// Append a component to a header
 pub fn build_header(headers: &mut HeaderMap, name: &str, value: &str) -> Result<()> {
-    let name = HeaderName::from_str(name).map_err(|err| Error::Request(Box::new(err)))?;
-    let value = HeaderValue::from_str(value).map_err(|err| Error::Request(Box::new(err)))?;
+    let name = HeaderName::from_str(name).map_err(Error::request)?;
+    let value = HeaderValue::from_str(value).map_err(Error::request)?;
     headers.append(name, value);
     Ok(())
 }
@@ -316,5 +316,5 @@ fn parse_json<T>(body: Bytes) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    serde_json::from_slice(body.as_ref()).map_err(|err| Error::Body(Box::new(err)))
+    serde_json::from_slice(body.as_ref()).map_err(Error::body)
 }

--- a/pretend/src/lib.rs
+++ b/pretend/src/lib.rs
@@ -220,12 +220,21 @@
 //!
 //!
 //! However, some clients are not thread-safe, and cannot be shared between threads. To use
-//! these clients with `Pretend`, you have toopt-out from the `Send` constraint on returned
+//! these clients with `Pretend`, you have to opt-out from the `Send` constraint on returned
 //! futures by using `#[pretend(?Send)]`. This is similar to what is done in [`async_trait`].
 //!
 //! [`async_trait`]: https://docs.rs/async-trait/latest/async_trait/
 //!
 //! Clients implementations that are not thread-safe are usually called "local clients".
+//!
+//! # Non-Send-Sync errors
+//!
+//! `pretend` boxes errors returned by the client in [`Error`]. By default, it requires the error
+//! to be `Send + Sync`. For some clients, especially local ones, this bound cannot be guaranteed.
+//!
+//! `pretend` offers the feature `local-error` as an escape latch. When enabled, this feature will
+//! drop the `Send + Sync` bound on boxed errors. This feature is enabled by default for
+//! `pretend-awc`, a local client that returns non-Send-Sync errors.
 //!
 //! # Available client implementations
 //!

--- a/pretend/tests/clients_tester.rs
+++ b/pretend/tests/clients_tester.rs
@@ -29,18 +29,27 @@ where
     }
 }
 
-pub struct TokioTestableClient {
-    client: Box<dyn Client>,
+pub struct TokioTestableClient<C>
+where
+    C: Client,
+{
+    client: C,
     runtime: Runtime,
 }
 
-impl TokioTestableClient {
-    pub fn new(client: Box<dyn Client>, runtime: Runtime) -> Self {
+impl<C> TokioTestableClient<C>
+where
+    C: Client,
+{
+    pub fn new(client: C, runtime: Runtime) -> Self {
         TokioTestableClient { client, runtime }
     }
 }
 
-impl TestableClient for TokioTestableClient {
+impl<C> TestableClient for TokioTestableClient<C>
+where
+    C: Client,
+{
     fn execute(
         &self,
         method: Method,
@@ -48,23 +57,32 @@ impl TestableClient for TokioTestableClient {
         headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<Response<Bytes>> {
-        self.runtime
-            .block_on(async { self.client.execute(method, url, headers, body).await })
+        let future = async { self.client.execute(method, url, headers, body).await };
+        self.runtime.block_on(future)
     }
 }
 
-pub struct TokioTestableLocalClient {
-    client: Box<dyn LocalClient>,
+pub struct TokioTestableLocalClient<C>
+where
+    C: LocalClient,
+{
+    client: C,
     runtime: Runtime,
 }
 
-impl TokioTestableLocalClient {
-    pub fn new(client: Box<dyn LocalClient>, runtime: Runtime) -> Self {
+impl<C> TokioTestableLocalClient<C>
+where
+    C: LocalClient,
+{
+    pub fn new(client: C, runtime: Runtime) -> Self {
         TokioTestableLocalClient { client, runtime }
     }
 }
 
-impl TestableClient for TokioTestableLocalClient {
+impl<C> TestableClient for TokioTestableLocalClient<C>
+where
+    C: LocalClient,
+{
     fn execute(
         &self,
         method: Method,
@@ -72,8 +90,8 @@ impl TestableClient for TokioTestableLocalClient {
         headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<Response<Bytes>> {
-        self.runtime
-            .block_on(async { self.client.execute(method, url, headers, body).await })
+        let future = async { self.client.execute(method, url, headers, body).await };
+        self.runtime.block_on(future)
     }
 }
 

--- a/pretend/tests/test_clients.rs
+++ b/pretend/tests/test_clients.rs
@@ -17,10 +17,7 @@ fn create_testable<C>(client: C) -> Box<dyn TestableClient>
 where
     C: Client + 'static,
 {
-    Box::new(TokioTestableClient::new(
-        Box::new(client),
-        runtimes::create_runtime(),
-    ))
+    Box::new(TokioTestableClient::new(client, runtimes::create_runtime()))
 }
 
 fn create_testable_local<C>(client: C) -> Box<dyn TestableClient>
@@ -28,7 +25,7 @@ where
     C: LocalClient + 'static,
 {
     Box::new(TokioTestableLocalClient::new(
-        Box::new(client),
+        client,
         runtimes::create_runtime(),
     ))
 }

--- a/tests/default-features-build/Cargo.toml
+++ b/tests/default-features-build/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pretend-test-default-feature-build"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+pretend = { path = "../../pretend" }
+pretend-codegen = { path = "../../pretend-codegen" }
+pretend-isahc = { path = "../../pretend-isahc" }
+pretend-reqwest = { path = "../../pretend-reqwest" }
+pretend-ureq = { path = "../../pretend-ureq" }
+
+[dev-dependencies]
+thiserror = "1.0"
+trybuild = "1.0"
+
+[workspace]

--- a/tests/default-features-build/src/lib.rs
+++ b/tests/default-features-build/src/lib.rs
@@ -1,0 +1,7 @@
+//! Tests for default features
+//!
+//! This crate tests if the default features (with Send + Sync errors) works well.
+//! It compiles all client crates that supports errors with Send and Sync bounds,
+//! to verify that they effectively supports these bounds. It also compiles a test
+//! client with an error that does not support these bounds, to make sure that it
+//! fails to compile.

--- a/tests/default-features-build/tests/builds/unsupported_client.rs
+++ b/tests/default-features-build/tests/builds/unsupported_client.rs
@@ -1,0 +1,26 @@
+use pretend::client::{BlockingClient, Bytes, Method};
+use pretend::{Error, HeaderMap, Response, Result, Url};
+use std::rc::Rc;
+use thiserror::Error;
+
+#[derive(Default, Debug, Error)]
+#[error("Test error")]
+struct TestError {
+    data: Rc<i32>,
+}
+
+struct TestClient;
+
+impl BlockingClient for TestClient {
+    fn execute(
+        &self,
+        _: Method,
+        _: Url,
+        _: HeaderMap,
+        _: Option<Bytes>,
+    ) -> Result<Response<Bytes>> {
+        Err(Error::response(TestError::default()))
+    }
+}
+
+fn main() {}

--- a/tests/default-features-build/tests/builds/unsupported_client.stderr
+++ b/tests/default-features-build/tests/builds/unsupported_client.stderr
@@ -1,0 +1,35 @@
+error[E0277]: `Rc<i32>` cannot be sent between threads safely
+  --> $DIR/unsupported_client.rs:22:13
+   |
+22 |         Err(Error::response(TestError::default()))
+   |             ^^^^^^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+   |
+  ::: $PRETEND/src/errors.rs
+   |
+   |     error::Error + 'static + Send + Sync
+   |                              ---- required by this bound in `pretend::Error::response`
+   |
+   = help: within `TestError`, the trait `Send` is not implemented for `Rc<i32>`
+note: required because it appears within the type `TestError`
+  --> $DIR/unsupported_client.rs:8:8
+   |
+8  | struct TestError {
+   |        ^^^^^^^^^
+
+error[E0277]: `Rc<i32>` cannot be shared between threads safely
+  --> $DIR/unsupported_client.rs:22:13
+   |
+22 |         Err(Error::response(TestError::default()))
+   |             ^^^^^^^^^^^^^^^ `Rc<i32>` cannot be shared between threads safely
+   |
+  ::: $PRETEND/src/errors.rs
+   |
+   |     error::Error + 'static + Send + Sync
+   |                                     ---- required by this bound in `pretend::Error::response`
+   |
+   = help: within `TestError`, the trait `Sync` is not implemented for `Rc<i32>`
+note: required because it appears within the type `TestError`
+  --> $DIR/unsupported_client.rs:8:8
+   |
+8  | struct TestError {
+   |        ^^^^^^^^^

--- a/tests/default-features-build/tests/test_builds.rs
+++ b/tests/default-features-build/tests/test_builds.rs
@@ -1,0 +1,5 @@
+#[test]
+fn test_builds() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/builds/*.rs");
+}


### PR DESCRIPTION
By default, errors that are boxed in pretend::Error
have the Send + Sync bound.

To support `pretend-awc`, a new feature `local-error` is
introduced to drop this requirement. This feature is enabled
by default for `pretend-awc`