### PR TITLE
Disabled default features for HTTP clients

### DIFF
--- a/pretend-awc/Cargo.toml
+++ b/pretend-awc/Cargo.toml
@@ -6,7 +6,7 @@ description = "awc based client for pretend."
 authors = ["Lucien XU <sfietkonstantin@free.fr>"]
 license = "MIT"
 homepage = "https://github.com/SfietKonstantin/pretend"
-documentation = "https://docs.rs/pretend-isahc/latest/pretend_awc/"
+documentation = "https://docs.rs/pretend-awc/latest/pretend_awc/"
 repository = "https://github.com/SfietKonstantin/pretend"
 keywords = ["http", "client", "web", "async", "declarative"]
 categories = ["web-programming::http-client"]
@@ -14,4 +14,7 @@ readme = "README.md"
 
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0", features = ["local-error"] }
-awc = "2.0"
+awc = { version = "2", default-features = false }
+
+[features]
+default = ["awc/default"]

--- a/pretend-isahc/Cargo.toml
+++ b/pretend-isahc/Cargo.toml
@@ -14,4 +14,7 @@ readme = "README.md"
 
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
-isahc = "1.3"
+isahc = { version = "1", default-features = false }
+
+[features]
+default = ["isahc/default"]

--- a/pretend-reqwest/Cargo.toml
+++ b/pretend-reqwest/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
-reqwest = { version = "0.11" }
+reqwest = { version = "0.11", default-features = false }
 
 [features]
-default = []
+default = ["reqwest/default"]
 blocking = ["reqwest/blocking"]

--- a/pretend-ureq/Cargo.toml
+++ b/pretend-ureq/Cargo.toml
@@ -6,12 +6,15 @@ description = "ureq based client for pretend."
 authors = ["Lucien XU <sfietkonstantin@free.fr>"]
 license = "MIT"
 homepage = "https://github.com/SfietKonstantin/pretend"
-documentation = "https://docs.rs/pretend-reqwest/latest/pretend_ureq/"
+documentation = "https://docs.rs/pretend-ureq/latest/pretend_ureq/"
 repository = "https://github.com/SfietKonstantin/pretend"
-keywords = ["http", "client", "web", "async", "declarative"]
+keywords = ["http", "client", "web", "declarative"]
 categories = ["web-programming::http-client"]
 readme = "README.md"
 
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
-ureq = "2.1"
+ureq = { version = "2", default-features = false }
+
+[features]
+default = ["ureq/default"]

--- a/pretend/src/lib.rs
+++ b/pretend/src/lib.rs
@@ -245,6 +245,34 @@
 //! - [`awc`](https://crates.io/crates/pretend-awc) (local async)
 //! - [`ureq`](https://crates.io/crates/pretend-ureq) (blocking)
 //!
+//! These client implementations depends on the latest major release of each HTTP client at
+//! time of the release. The `default` feature for each of the HTTP client crate is also mapped
+//! to the `pretend-*` crate. To enable HTTP client features, you should add it as a dependency
+//! and enable them here. If needed, you can play with the `default-features` option on the
+//! `pretend-*` crate.
+//!
+//! The following snippet will enable `reqwest` default features
+//!
+//! ```toml
+//! [dependencies]
+//! pretend-reqwest = "0.2.2"
+//! ```
+//!
+//! In the following snippet, no feature of `reqwest` will be enabled
+//!
+//! ```toml
+//! [dependencies]
+//! pretend-reqwest = { version = "0.2.2", default-features = false }
+//! ```
+//!
+//! To use `reqwest` with rustls instead of the native-tls, you can do the following:
+//!
+//! ```toml
+//! [dependencies]
+//! pretend-reqwest = { version = "0.2.2", default-features = false }
+//! reqwest = { version = "*", default-features = false, features = ["rustls-tls"] }
+//! ```
+//!
 //! # Implementing a `pretend` HTTP client
 //!
 //! `pretend` clients wraps HTTP clients from other crates. They allow [`Pretend`] to execute

--- a/tests/default-features-build/Cargo.toml
+++ b/tests/default-features-build/Cargo.toml
@@ -7,12 +7,14 @@ edition = "2018"
 pretend = { path = "../../pretend" }
 pretend-codegen = { path = "../../pretend-codegen" }
 
-pretend-isahc = { path = "../../pretend-isahc" }
-pretend-reqwest = { path = "../../pretend-reqwest" }
-pretend-ureq = { path = "../../pretend-ureq" }
+pretend-isahc = { path = "../../pretend-isahc", default-features = false }
+pretend-reqwest = { path = "../../pretend-reqwest", default-features = false }
+pretend-ureq = { path = "../../pretend-ureq", default-features = false }
 
 [dev-dependencies]
+anyhow = "1.0"
 thiserror = "1.0"
+tokio = { version = "1.5", features = ["macros", "rt-multi-thread"] }
 trybuild = "1.0"
 
 [workspace]

--- a/tests/default-features-build/src/lib.rs
+++ b/tests/default-features-build/src/lib.rs
@@ -5,3 +5,6 @@
 //! to verify that they effectively supports these bounds. It also compiles a test
 //! client with an error that does not support these bounds, to make sure that it
 //! fails to compile.
+//!
+//! It also test if, by default, pretend-* crates are compiled without any feature
+//! in the client crate.

--- a/tests/default-features-build/tests/test_no_https.rs
+++ b/tests/default-features-build/tests/test_no_https.rs
@@ -1,0 +1,42 @@
+use pretend::{pretend, request, Pretend, Result, Url};
+
+#[pretend]
+trait HttpBin {
+    #[request(method = "GET", path = "/get")]
+    async fn get(&self) -> Result<()>;
+}
+
+#[pretend]
+trait HttpBinSync {
+    #[request(method = "GET", path = "/get")]
+    fn get(&self) -> Result<()>;
+}
+
+#[tokio::test]
+async fn test_reqwest_no_https_feature() {
+    // With default-features = false
+    // reqwest will not use any TLS crate,
+    // and thus, cannot handle https calls
+
+    let url = Url::parse("https://httpbin.org").unwrap();
+    let pretend = Pretend::for_client(pretend_reqwest::Client::default()).with_url(url);
+    let result = pretend.get().await;
+
+    let error = anyhow::Error::from(result.unwrap_err());
+    assert!(format!("{:?}", error).contains("scheme is not http"));
+}
+
+#[test]
+fn test_ureq_no_https_feature() {
+    // With default-features = false
+    // ureq will not use any TLS crate,
+    // and thus, cannot handle https calls
+
+    let url = Url::parse("https://httpbin.org").unwrap();
+    let pretend =
+        Pretend::for_client(pretend_ureq::Client::new(pretend_ureq::ureq::agent())).with_url(url);
+    let result = pretend.get();
+
+    let error = anyhow::Error::from(result.unwrap_err());
+    assert!(format!("{:?}", error).contains("ureq was build without HTTP support"));
+}


### PR DESCRIPTION
By doing this, `pretend` users can specify
the features they want.