### PR TITLE
Enforced Rust 1.44 MSRV

### DIFF
--- a/pretend-awc/Cargo.toml
+++ b/pretend-awc/Cargo.toml
@@ -15,3 +15,4 @@ readme = "README.md"
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0", features = ["local-error"] }
 awc = "2.0"
+bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44

--- a/pretend-reqwest/Cargo.toml
+++ b/pretend-reqwest/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
 reqwest = { version = "0.11" }
+bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44
 hyper = ">=0.14, <0.14.5" # Make socket2 compatible with Rust 1.44
 
 [features]

--- a/pretend/Cargo.toml
+++ b/pretend/Cargo.toml
@@ -27,6 +27,7 @@ url = "2.2"
 
 [dev-dependencies]
 actix-web = "3.3"
+bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44
 pretend-awc = { path = "../pretend-awc" }
 pretend-isahc = { path = "../pretend-isahc" }
 pretend-reqwest = { path = "../pretend-reqwest", features = ["blocking"] }


### PR DESCRIPTION
This commit forces bitflags to be downgraded to <1.3
to enforce Rust 1.44 MSRV (no if in const).