### PR TITLE
Moved MSRV enforcements as separate test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,15 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.44.0"
-          default: true
-
-      - run: cargo test
-
-  test-latest:
-    strategy:
-      matrix:
         toolchain:
           - stable
           - beta
-    runs-on: ubuntu-latest
+        exclude:
+          - os: macos-latest
+            toolchain: beta
+          - os: windows-latest
+            toolchain: beta
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 
@@ -54,6 +44,19 @@ jobs:
           default: true
 
       - run: cd tests/default-features-build && cargo test
+
+  test-msrv-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.44.0"
+          default: true
+
+      - run: cd tests/msrv-check && cargo build
 
   analyze:
     runs-on: ubuntu-latest

--- a/pretend-awc/Cargo.toml
+++ b/pretend-awc/Cargo.toml
@@ -15,4 +15,3 @@ readme = "README.md"
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0", features = ["local-error"] }
 awc = "2.0"
-bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44

--- a/pretend-isahc/Cargo.toml
+++ b/pretend-isahc/Cargo.toml
@@ -15,4 +15,3 @@ readme = "README.md"
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
 isahc = "1.3"
-curl = ">=0.4, <0.4.36" # Make socket2 compatible with Rust 1.44

--- a/pretend-reqwest/Cargo.toml
+++ b/pretend-reqwest/Cargo.toml
@@ -15,8 +15,6 @@ readme = "README.md"
 [dependencies]
 pretend = { path = "../pretend",  version = "0.2.0" }
 reqwest = { version = "0.11" }
-bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44
-hyper = ">=0.14, <0.14.5" # Make socket2 compatible with Rust 1.44
 
 [features]
 default = []

--- a/pretend/Cargo.toml
+++ b/pretend/Cargo.toml
@@ -27,7 +27,6 @@ url = "2.2"
 
 [dev-dependencies]
 actix-web = "3.3"
-bitflags = ">=1.2.0, <1.3.0" # Compatibility with Rust 1.44
 pretend-awc = { path = "../pretend-awc" }
 pretend-isahc = { path = "../pretend-isahc" }
 pretend-reqwest = { path = "../pretend-reqwest", features = ["blocking"] }

--- a/tests/msrv-check/Cargo.toml
+++ b/tests/msrv-check/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pretend-test-default-feature-build"
+name = "pretend-msrv-check"
 version = "0.0.0"
 edition = "2018"
 
@@ -7,12 +7,14 @@ edition = "2018"
 pretend = { path = "../../pretend" }
 pretend-codegen = { path = "../../pretend-codegen" }
 
+pretend-awc = { path = "../../pretend-awc" }
 pretend-isahc = { path = "../../pretend-isahc" }
 pretend-reqwest = { path = "../../pretend-reqwest" }
 pretend-ureq = { path = "../../pretend-ureq" }
 
-[dev-dependencies]
-thiserror = "1.0"
-trybuild = "1.0"
+# Enforce MSRV
+bitflags = ">=1.2, <1.3.0"
+hyper = ">=0.14, <0.14.5"
+isahc = ">=1.3, <1.4.0"
 
 [workspace]

--- a/tests/msrv-check/src/lib.rs
+++ b/tests/msrv-check/src/lib.rs
@@ -1,0 +1,5 @@
+//! Tests MSRV
+//!
+//! This crate tests if Pretend compiles with MSRV (Rust 1.44).
+//! It contains constraints on 3rd party crates to make them compile
+//! with MSRV.


### PR DESCRIPTION
Removed constraints on dependencies in pretend-*
crates so that latest clients can be used for
stable Rust users.

A specific test is introduced to make sure that,
with some constraints, MSRV can still be Rust 1.44.