### PR TITLE
Made sure (doc) attributs are propagated to trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
 
       - run: cd tests/default-features-build && cargo test
 
+  test-doc-propagation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - run: cd tests/doc-propagation && cargo test
+
   test-msrv-check:
     runs-on: ubuntu-latest
     steps:

--- a/pretend-codegen/src/lib.rs
+++ b/pretend-codegen/src/lib.rs
@@ -29,6 +29,7 @@ fn implement_pretend(attr: PretendAttr, item: ItemTrait) -> Result<TokenStream2>
     let name = &item.ident;
     let vis = &item.vis;
     let items = &item.items;
+    let attrs = &item.attrs;
     let trait_items = items.iter().map(trait_item).collect::<Vec<_>>();
 
     let kind = parse_client_kind(name, attr, items)?;
@@ -43,6 +44,7 @@ fn implement_pretend(attr: PretendAttr, item: ItemTrait) -> Result<TokenStream2>
     let send_sync = send_sync_traits_impl(&kind);
     let tokens = quote! {
         #attr
+        #(#attrs)*
         #vis trait #name {
             #(#trait_items)*
         }

--- a/tests/doc-propagation/Cargo.toml
+++ b/tests/doc-propagation/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pretend-test-doc-propagation"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+pretend = { path = "../../pretend" }
+pretend-codegen = { path = "../../pretend-codegen" }
+
+[workspace]

--- a/tests/doc-propagation/src/lib.rs
+++ b/tests/doc-propagation/src/lib.rs
@@ -1,0 +1,13 @@
+//! Test crate
+
+#![forbid(missing_docs)]
+
+use pretend::{pretend, Result};
+
+/// This REST endpoints tests documentation features
+#[pretend]
+trait TestTrait {
+    /// Documentation for a simple method
+    #[request(method = "GET", path = "/api/v1/test")]
+    async fn test(&self) -> Result<String>;
+}


### PR DESCRIPTION
This commit propagates attributes to the generated trait, so that doc (among other attributes) are
correctly available in the generated trait.